### PR TITLE
`/smartthings/security/.../config` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,10 @@ ADT Pulse contact (door, window, etc.) and motion detection devices may be expos
 
 **&#9432;** Note that the MQTT Discovery edge driver does not currently support security panel devices, so there is no current support for either status or configuration of the ADT Pulse alarm system ("armed", "disarmed", "home", "away", etc.) via SmartThings. Only contact and motion devices are currently supported, though siren and/or panel support may come in a future update.
 
-1. Make sure the `adt-mqtt-pulse` application is configured and running properly.
-2. Follow instructions to set up the [MQTT Discover edge driver](https://github.com/toddaustin07/MQTT-Discovery?tab=readme-ov-file#instructions).
-3. Upon refresh in the SmartThings application, you should see ADT devices appear.
+1. Make sure an MQTT server is set up and available.
+2. Follow instructions to set up the [MQTT Discover edge driver](https://github.com/toddaustin07/MQTT-Discovery?tab=readme-ov-file#instructions) to subscribe to that MQTT server.
+3. Set up and ensure the `adt-mqtt-pulse` application is configured and running properly, pointing to the same MQTT server.
+4. Upon refresh in the MQTT Discovery device in SmartThings application as per setup instructions, you should see ADT devices appear.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg

--- a/adt-pulse-mqtt/server.js
+++ b/adt-pulse-mqtt/server.js
@@ -32,7 +32,9 @@ client.on("connect", function () {
   console.log("MQTT Sub to: " + alarm_command_topic);
   client.subscribe(alarm_command_topic);
   if (smartthings) {
-    client.subscribe(smartthings_topic + "/security/ADT Alarm System/state");
+    client.subscribe(
+      smartthings_topic + "_future/security/ADT Alarm System/state",
+    );
   }
 });
 
@@ -43,7 +45,7 @@ client.on("message", function (topic, message) {
 
   if (
     smartthings &&
-    topic == smartthings_topic + "/security/ADT Alarm System/state" &&
+    topic == smartthings_topic + "_future/security/ADT Alarm System/state" &&
     message.toString().includes("_push")
   ) {
     var toState = null;
@@ -149,7 +151,7 @@ myAlarm.onStatusUpdate(function (device) {
     client.publish(alarm_state_topic, mqtt_state, { retain: true });
     if (smartthings) {
       var sm_alarm_topic =
-        smartthings_topic + "/security/ADT Alarm System/config";
+        smartthings_topic + "_future/security/ADT Alarm System/config";
       console.log(
         new Date().toLocaleString() +
           " Pushing alarm state to smartthings" +


### PR DESCRIPTION
Patch to eliminate problems with `/smartthings/security/.../config` causing MQTT Discovery edge driver to fail.  Solved by moving those topics to `/smartthings_future/security/.../config` until the MQTT Discovery edge driver can be updated to support Security Panel devices.

Also updated `README` to note proper steps in order to avoid race condition from `/smartthings/.../config` messages being fired off before the MQTT Discovery device has subscribed to them.