### PR TITLE
chore: upgrade Alpine base images from 3.21 to 3.22

### DIFF
--- a/adt-pulse-mqtt/Dockerfile-aarch64
+++ b/adt-pulse-mqtt/Dockerfile-aarch64
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/aarch64-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/adt-pulse-mqtt/Dockerfile-amd64
+++ b/adt-pulse-mqtt/Dockerfile-amd64
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/amd64-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/adt-pulse-mqtt/Dockerfile-armhf
+++ b/adt-pulse-mqtt/Dockerfile-armhf
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/armv7hf-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/adt-pulse-mqtt/build.yaml
+++ b/adt-pulse-mqtt/build.yaml
@@ -2,8 +2,8 @@
 #squash: false
 build_from:
   #aarch64: balenalib/aarch64-alpine:3.21-run
-  aarch64: alpine:3.21
+  aarch64: alpine:3.22
   #amd64: balenalib/amd64-alpine:3.21-run
-  amd64: alpine:3.21
+  amd64: alpine:3.22
   #armhf: balenalib/armv7hf-alpine:3.21-run
   #armhf: alpine:3.21

--- a/test-adt-pulse-mqtt/Dockerfile-aarch64
+++ b/test-adt-pulse-mqtt/Dockerfile-aarch64
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/aarch64-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/test-adt-pulse-mqtt/Dockerfile-amd64
+++ b/test-adt-pulse-mqtt/Dockerfile-amd64
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/amd64-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/test-adt-pulse-mqtt/build.yaml
+++ b/test-adt-pulse-mqtt/build.yaml
@@ -2,8 +2,8 @@
 #squash: false
 build_from:
   #aarch64: balenalib/aarch64-alpine:3.21-run
-  aarch64: alpine:3.21
+  aarch64: alpine:3.22
   #amd64: balenalib/amd64-alpine:3.21-run
-  amd64: alpine:3.21
+  amd64: alpine:3.22
   #armhf: balenalib/armv7hf-alpine:3.21-run
   #armhf: alpine:3.21

--- a/x-adt-pulse-mqtt-test-alpha/Dockerfile-aarch64
+++ b/x-adt-pulse-mqtt-test-alpha/Dockerfile-aarch64
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/aarch64-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/x-adt-pulse-mqtt-test-alpha/Dockerfile-amd64
+++ b/x-adt-pulse-mqtt-test-alpha/Dockerfile-amd64
@@ -1,5 +1,5 @@
 #ARG BUILD_FROM=balenalib/amd64-alpine:3.21-run
-ARG BUILD_FROM=alpine:3.21
+ARG BUILD_FROM=alpine:3.22
 FROM $BUILD_FROM
 
 ENV LANG=C.UTF-8

--- a/x-adt-pulse-mqtt-test-alpha/build.yaml
+++ b/x-adt-pulse-mqtt-test-alpha/build.yaml
@@ -2,6 +2,6 @@
 #squash: false
 build_from:
   #aarch64: balenalib/aarch64-alpine:3.21-run
-  aarch64: alpine:3.21
+  aarch64: alpine:3.22
   #amd64: balenalib/amd64-alpine:3.21-run
-  amd64: alpine:3.21
+  amd64: alpine:3.22


### PR DESCRIPTION
## Summary

Upgrade Alpine base images from 3.21 to 3.22 across all addons.

## Why

Alpine 3.21 ships **npm 10.9.1**, while lock file maintenance (Renovate) generates lock files using **npm 11.x**. npm 10 rejects these lock files due to different dependency hoisting behavior for `undici` (a transitive dependency of `cheerio` and optional peer dep of `http-cookie-agent`).

This causes `npm ci` failures in:
- **Docker Hub - amd64** workflow
- **Docker Hub - aarch64** workflow  
- **Node.js CI** workflow

## What changes

Alpine 3.22 ships **Node.js 22.22.0** and **npm 11.6.4**, matching the npm version used for lock file generation.

| | Alpine 3.21 | Alpine 3.22 |
|---|---|---|
| Node.js | 22.15.1 | 22.22.0 |
| npm | 10.9.1 | 11.6.4 |

## Files changed

- `build.yaml` across all 3 addons
- `Dockerfile-amd64` across all 3 addons
- `Dockerfile-aarch64` across all 3 addons  
- `Dockerfile-armhf` (adt-pulse-mqtt only)