### PR TITLE
chore: migrate HA builder to new workflow format (2026.03.2)

### DIFF
--- a/.github/workflows/build-addon.yaml
+++ b/.github/workflows/build-addon.yaml
@@ -1,0 +1,130 @@
+name: Build addon
+
+on:
+  workflow_call:
+    inputs:
+      addon:
+        required: true
+        type: string
+      publish:
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  prepare:
+    name: Prepare ${{ inputs.addon }}
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.matrix.outputs.matrix }}
+      version: ${{ steps.matrix.outputs.version }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
+      - name: Get addon information
+        id: info
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "./${{ inputs.addon }}"
+
+      - name: Prepare build matrix
+        id: matrix
+        shell: bash
+        env:
+          ARCHITECTURES: ${{ steps.info.outputs.architectures }}
+          IMAGE: ${{ steps.info.outputs.image }}
+          VERSION: ${{ steps.info.outputs.version }}
+          ADDON_PATH: "./${{ inputs.addon }}"
+        run: |
+          # Strip JSON quotes from info action outputs (yq -o=json wraps strings in quotes)
+          IMAGE="${IMAGE//\"/}"
+          VERSION="${VERSION//\"/}"
+
+          if [[ "$IMAGE" == "null" || -z "$IMAGE" ]]; then
+            echo "::error::Image property is not defined for ${{ inputs.addon }}"
+            exit 1
+          fi
+
+          # Find build file (build.yaml/yml/json) for BUILD_FROM values
+          build_file=""
+          for ext in yaml yml json; do
+            if [[ -f "${ADDON_PATH}/build.${ext}" ]]; then
+              build_file="${ADDON_PATH}/build.${ext}"
+              break
+            fi
+          done
+
+          matrix='{"include":[]}'
+          for arch in $(jq -r '.[]' <<< "${ARCHITECTURES}"); do
+            case "${arch}" in
+              amd64)   os="ubuntu-24.04" ;;
+              aarch64) os="ubuntu-24.04-arm" ;;
+              *)
+                echo "::error::Unsupported architecture: ${arch}. Supported: amd64, aarch64"
+                exit 1
+                ;;
+            esac
+            # Replace {arch} placeholder in image name from config.yaml
+            image="${IMAGE//\{arch\}/${arch}}"
+
+            # Read base image from build file
+            build_from=""
+            if [[ -n "$build_file" ]]; then
+              build_from=$(yq e -N -M ".build_from.${arch}" "$build_file")
+              if [[ "$build_from" == "null" ]]; then
+                build_from=""
+              fi
+            fi
+
+            if [[ -z "$build_from" ]]; then
+              echo "::error::No build_from defined for arch ${arch} in ${{ inputs.addon }}"
+              exit 1
+            fi
+
+            matrix=$(jq -c --arg arch "$arch" --arg os "$os" --arg image "$image" --arg build_from "$build_from" \
+              '.include += [{arch: $arch, os: $os, image: $image, build_from: $build_from}]' <<< "${matrix}")
+          done
+
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          jq . <<< "${matrix}"
+
+  build:
+    name: Build ${{ matrix.arch }} image
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build ${{ inputs.addon }} add-on
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.arch }}
+          build-args: |
+            BUILD_FROM=${{ matrix.build_from }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          context: "./${{ inputs.addon }}"
+          image: ${{ matrix.image }}
+          image-tags: |
+            ${{ needs.prepare.outputs.version }}
+            latest
+          push: ${{ inputs.publish }}
+          version: ${{ needs.prepare.outputs.version }}
+          #--no-cache: use cache-gha: "false" to disable caching
+        #env:
+        #  CAS_API_KEY: ${{ secrets.CAS_API_KEY }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -2,13 +2,13 @@ name: Builder
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   packages: write
 
 env:
-  BUILD_ARGS: "--test"
   MONITORED_FILES: "build.yaml config.yaml Dockerfile rootfs"
-  #MONITORED_FILES: "Dockerfile rootfs"   
+  #MONITORED_FILES: "Dockerfile rootfs"
 
 on:
   workflow_dispatch:
@@ -21,12 +21,12 @@ on:
       - main
       - master
   #workflow_run:
-  #  workflows: ["Lint"]    
+  #  workflows: ["Lint"]
   #  types: [completed]
 
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.ref }}
-#  cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   init:
@@ -41,6 +41,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
+        if: github.event_name != 'workflow_dispatch'
         #uses: jitterbit/get-changed-files@v1
         uses: HanseltimeIndustries/get-changed-files@v1.1.2
 
@@ -50,36 +51,19 @@ jobs:
 
       - name: Get changed add-ons
         id: changed_addons
+        env:
+          CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
-          
-          # Get list of all changed files as array
-          IFS=' ' read -ra CHANGED_FILES <<< "${{ steps.changed_files.outputs.all }}"
-          
-          # Check each addon individually
           for addon in ${{ steps.addons.outputs.addons }}; do
-            addon_changed=false
-            
-            # Check if any of the addon's monitored files changed
-            for changed_file in "${CHANGED_FILES[@]}"; do
-              # Extract directory and filename from changed file
-              if [[ "$changed_file" == "$addon/"* ]]; then
-                file_basename=$(basename "$changed_file")
-                # Check if this basename matches any monitored file
-                for monitored in ${{ env.MONITORED_FILES }}; do
-                  if [[ "$file_basename" == "$monitored" ]] || [[ "$changed_file" == "$addon/$monitored" ]]; then
-                    addon_changed=true
-                    break 2
+            if [[ "$CHANGED_FILES" =~ $addon ]]; then
+              for file in ${{ env.MONITORED_FILES }}; do
+                  if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
+                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
+                      changed_addons+=("\"${addon}\",");
+                    fi
                   fi
-                done
-              fi
-            done
-            
-            # Add to changed list if found
-            if [[ "$addon_changed" == true ]]; then
-              if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
-                changed_addons+=("\"${addon}\",");
-              fi
+              done
             fi
           done
 
@@ -92,59 +76,19 @@ jobs:
           else
             echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
           fi
+
   build:
     needs: init
-    runs-on: ubuntu-latest
     if: needs.init.outputs.changed == 'true'
-    name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
     strategy:
+      fail-fast: false
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        #arch: ["aarch64", "amd64", "armhf"]
-        arch: ["aarch64", "amd64"]
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Get information
-        id: info
-        uses: home-assistant/actions/helpers/info@master
-        with:
-          path: "./${{ matrix.addon }}"
-
-      - name: Check if add-on should be built
-        id: check
-        run: |
-          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-             echo "build_arch=true" >> $GITHUB_OUTPUT;
-             echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-             if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                 echo "BUILD_ARGS=" >> $GITHUB_ENV;
-             fi
-           else
-             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-             echo "build_arch=false" >> $GITHUB_OUTPUT;
-          fi
-
-      - name: Login to GitHub Container Registry
-        if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Build ${{ matrix.addon }} add-on
-        if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.02.1
-        #env:
-        #  CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
-        with:
-          args: |
-            ${{ env.BUILD_ARGS }} \
-            --${{ matrix.arch }} \
-            --target /data/${{ matrix.addon }} \
-            --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
-            --addon
+    uses: ./.github/workflows/build-addon.yaml
+    with:
+      addon: ${{ matrix.addon }}
+      publish: ${{ github.event_name == 'push' }}
+    secrets: inherit
+    #permissions:
+    #  contents: read
+    #  packages: write


### PR DESCRIPTION
## Summary

Migrate the Home Assistant builder workflow from the legacy container-based `home-assistant/builder@2026.02.1` to the new action-based `home-assistant/builder/actions/build-image@2026.03.2` format.

## Changes

- **`.github/workflows/builder.yaml`**: Simplified to detect changed addons and delegate to the reusable `build-addon.yaml` workflow
- **`.github/workflows/build-addon.yaml`** (new): Reusable workflow that prepares a per-architecture build matrix and uses the new builder action with native arm runners

## Key improvements

- Uses native `ubuntu-24.04-arm` runners for aarch64 builds (no QEMU emulation)
- Adds `id-token: write` permission for attestation support
- Adds concurrency control to prevent duplicate builds
- Cleaner separation of concerns (init → build delegation)

Mirrors the approach used in the `homeassistant-addons-onstar2mqtt` repository.